### PR TITLE
[FIX] odoo-shippable: Fix infinite loop when start postgresql services

### DIFF
--- a/odoo-shippable/files/entrypoint_image
+++ b/odoo-shippable/files/entrypoint_image
@@ -38,8 +38,7 @@ def docker_entrypoint():
     psql_version = os.environ.get('PSQL_VERSION', '9.3')
     psql_vstr = psql_version.replace('.', '')
     cmd = '/etc/init.d/postgresql start {version} main{psql_version}'.format(version=psql_version, psql_version=psql_vstr)
-    ppostgres = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    ppostgres.wait()
+    subprocess.call(cmd, shell=True)
     print("Waiting to start psql service...")
     count = 0
     max_count = 40


### PR DESCRIPTION
- This is a strange issue, because locally works fine without this patch, but with docker in docker don't works
